### PR TITLE
Clear search after the transition has ended

### DIFF
--- a/select/index.html
+++ b/select/index.html
@@ -137,7 +137,9 @@
 
                         this.focusedOptionIndex = null
 
-                        this.search = ''
+                        setTimeout(() => {
+                            this.search = ''
+                        }, 100)
                     },
 
                     focusNextOption: function () {


### PR DESCRIPTION
Because of the transition when closing the listbox, before it actually closes (visually) you can notice the search reset which populates all the original options.